### PR TITLE
Improve names and version numbers for Modrinth versions

### DIFF
--- a/platforms/fabric-1.16/build.gradle.kts
+++ b/platforms/fabric-1.16/build.gradle.kts
@@ -170,7 +170,7 @@ val publishModrinth by tasks.registering(TaskModrinthUpload::class) {
     token = System.getenv("MODRINTH_TOKEN") // An environment property called MODRINTH_TOKEN that is your token, set via Gradle CLI, GitHub Actions, Idea Run Configuration, or other
 
     projectId = "O7RBXm3n"
-    versionNumber = "Inventory Profiles Next-$mod_loader-$minecraft_version-$mod_version" // Will fail if Modrinth has this version already
+    versionNumber = "$mod_loader-$minecraft_version-$mod_version" // Will fail if Modrinth has this version already
     // On fabric, use 'remapJar' instead of 'jar'
     this.changelog
     val fabricRemapJar = tasks.named<org.gradle.jvm.tasks.Jar>("remapShadedJar").get()
@@ -184,7 +184,7 @@ val publishModrinth by tasks.registering(TaskModrinthUpload::class) {
         Will release ${remappedJarFile.get().asFile.path}
         +*************************************************+
     """.trimIndent())
-    versionName = "Inventory Profiles Next-$mod_loader-$minecraft_version-$mod_version"
+    versionName = "IPN $mod_version for $mod_loader $minecraft_version"
     changelog = project.rootDir.resolve("changelog.md").readText()
     addLoader(mod_loader)
 }

--- a/platforms/fabric-1.17/build.gradle.kts
+++ b/platforms/fabric-1.17/build.gradle.kts
@@ -180,7 +180,7 @@ val publishModrinth by tasks.registering(TaskModrinthUpload::class) {
     token = System.getenv("MODRINTH_TOKEN") // An environment property called MODRINTH that is your token, set via Gradle CLI, GitHub Actions, Idea Run Configuration, or other
 
     projectId = "O7RBXm3n"
-    versionNumber = "Inventory Profiles Next-$mod_loader-$minecraft_version-$mod_version" // Will fail if Modrinth has this version already
+    versionNumber = "$mod_loader-$minecraft_version-$mod_version" // Will fail if Modrinth has this version already
     // On fabric, use 'remapJar' instead of 'jar'
     this.changelog
     val fabricRemapJar = tasks.named<RemapJarTask>("remapShadedJar").get()
@@ -194,7 +194,7 @@ val publishModrinth by tasks.registering(TaskModrinthUpload::class) {
     supported_minecraft_versions.forEach { ver ->
         addGameVersion(ver) // Call this multiple times to add multiple game versions. There are tools that can help you generate the list of versions
     }
-    versionName = "Inventory Profiles Next-$mod_loader-$minecraft_version-$mod_version"
+    versionName = "IPN $mod_version for $mod_loader $minecraft_version"
     changelog = project.rootDir.resolve("changelog.md").readText()
 
     addLoader(mod_loader)

--- a/platforms/forge-1.16/build.gradle.kts
+++ b/platforms/forge-1.16/build.gradle.kts
@@ -361,7 +361,7 @@ val publishModrinth by tasks.registering(TaskModrinthUpload::class) {
     token = System.getenv("MODRINTH_TOKEN") // An environment property called MODRINTH that is your token, set via Gradle CLI, GitHub Actions, Idea Run Configuration, or other
 
     projectId = "O7RBXm3n"
-    versionNumber = "Inventory Profiles Next-$mod_loader-$minecraft_version-$mod_version" // Will fail if Modrinth has this version already
+    versionNumber = "$mod_loader-$minecraft_version-$mod_version" // Will fail if Modrinth has this version already
     // On fabric, use 'remapJar' instead of 'jar'
     this.changelog
 
@@ -371,7 +371,7 @@ val publishModrinth by tasks.registering(TaskModrinthUpload::class) {
     supported_minecraft_versions.forEach { ver ->
         addGameVersion(ver) // Call this multiple times to add multiple game versions. There are tools that can help you generate the list of versions
     }
-    versionName = "Inventory Profiles Next-$mod_loader-$minecraft_version-$mod_version"
+    versionName = "IPN $mod_version for $mod_loader $minecraft_version"
     changelog = project.rootDir.resolve("changelog.md").readText()
     addLoader(mod_loader)
 


### PR DESCRIPTION
This improves the names and version numbers for versions on the Modrinth project.
First, it changes the version name from `Inventory Profiles Next-$mod_loader-$minecraft_version-$mod_version` to `IPN $mod_version for $mod_loader $minecraft_version`; this means, instead of being displayed as `Inventory Profiles Next-fabric-1.17-0.8.3`, it will be displayed as `IPN 0.8.3 for fabric 1.17`.
It also changes the version number listed to match the name of the jar. Instead of the version number being `Inventory Profiles Next-$mod_loader-$minecraft_version-$mod_version`, it will now be `$mod_loader-$minecraft_version-$mod_version`; this means, instead of being displayed as `Inventory Profiles Next-fabric-1.17-0.8.3`, the version number will be displayed as `fabric-1.17-0.8.3`.
Why is this important? Firstly, it improves readability for the end user and for anyone looking at the mod's versions.
Secondly, it allows mod developers to use Modrinth's Maven functionality with InvProNext. Because Gradle is very weird, it does not allow the use of artifacts with spaces in the name (URI encoded or not). By removing the spaces and removing the overall strangeness of the version number, it will allow developers to leverage Modrinth's Maven in order to include it in their development environments.
In case you want to document the use of Modrinth's Maven, the repository is located at `https://api.modrinth.com/maven`, and the artifact (after this PR) would be `maven.modrinth:inventory-profiles-next:fabric-1.17-0.8.3` (change loader, MC version, and mod version as necessary).
By the way - thank you for maintaining InvPro for these versions, and thank you for using Modrinth! :D This is the only thing that's kind of irked me; otherwise, thank you greatly and keep up the great work. :)