### PR TITLE
Remove deprecated client-side-only ModMenu markers

### DIFF
--- a/platforms/fabric-1.16/src/main/resources/fabric.mod.json
+++ b/platforms/fabric-1.16/src/main/resources/fabric.mod.json
@@ -30,11 +30,5 @@
     "fabric-resource-loader-v0": "*",
     "fabricloader": ">=0.11.6",
     "minecraft": ">=1.16"
-  },
-  "suggests": {
-    "flamingo": "*"
-  },
-  "custom": {
-    "modmenu:clientsideOnly": true
   }
 }

--- a/platforms/fabric-1.17/src/main/resources/fabric.mod.json
+++ b/platforms/fabric-1.17/src/main/resources/fabric.mod.json
@@ -30,11 +30,5 @@
     "fabric-resource-loader-v0": "*",
     "fabricloader": ">=0.11.6",
     "minecraft": ">=1.17"
-  },
-  "suggests": {
-    "flamingo": "*"
-  },
-  "custom": {
-    "modmenu:clientsideOnly": true
   }
 }


### PR DESCRIPTION
This causes a log message: `[11:59:03] [Render thread/WARN]: WARNING! Mod inventoryprofilesnext is only using deprecated 'modmenu:clientsideOnly' custom value! This is no longer needed and will be removed in 1.18 snapshots.` It now infers that it is a client-side-only mod from the `"environment": "client"` marker.

Also removes the suggests flamingo thing, because flamingo is still there from the example mod.