### PR TITLE
Implement stackable threshold for refill

### DIFF
--- a/shared-sources/src/main/java/org/anti_ad/mc/ipnext/config/Configs.kt
+++ b/shared-sources/src/main/java/org/anti_ad/mc/ipnext/config/Configs.kt
@@ -184,6 +184,9 @@ object AutoRefillSettings : ConfigDeclaration {
     val REFILL_ARMOR                              /**/ by keyToggleBool(true)
     val REFILL_BEFORE_TOOL_BREAK                  /**/ by keyToggleBool(true)
     val AUTOREFILL_BLACKLIST                      /**/ by handledString("", AutoRefillHandler::blackListChanged)
+    val STACKABLE_THRESHOLD                     /**/ by int(0,
+                                                              0,
+                                                              64)
     val TOOL_DAMAGE_THRESHOLD                     /**/ by int(10,
                                                               0,
                                                               100)

--- a/shared-sources/src/main/java/org/anti_ad/mc/ipnext/event/AutoRefillHandler.kt
+++ b/shared-sources/src/main/java/org/anti_ad/mc/ipnext/event/AutoRefillHandler.kt
@@ -77,6 +77,7 @@ import org.anti_ad.mc.ipnext.item.`(saturationModifier)`
 import org.anti_ad.mc.ipnext.item.isFullBucket
 import org.anti_ad.mc.ipnext.item.isFullComparedTo
 import org.anti_ad.mc.ipnext.item.isHoneyBottle
+import org.anti_ad.mc.ipnext.item.isStackable
 import org.anti_ad.mc.ipnext.item.isStew
 import org.anti_ad.mc.ipnext.item.itemId
 import org.anti_ad.mc.ipnext.item.maxDamage
@@ -280,6 +281,8 @@ object AutoRefillHandler {
             if (storedItem.isEmpty()) return false // nothing become anything
             if (currentItem.isEmpty()) {
                 return !(AutoRefillSettings.DISABLE_FOR_LOYALTY_ITEMS.value && storedItem.itemType.enchantments[Enchantments.LOYALTY] != null)
+            } else if (currentItem.itemType.isStackable && currentItem.count <= AutoRefillSettings.STACKABLE_THRESHOLD.integerValue) {
+                return true
             }
             val itemType = currentItem.itemType
             if (itemType.isDamageable) {
@@ -512,6 +515,11 @@ object AutoRefillHandler {
                 } else {
                     // find item
                     filtered = defaultItemMatch(filtered, itemType)
+                    if (checkingItem.count > 1) {
+                        filtered = filtered.filter {
+                            it.value.count > checkingItem.count
+                        }
+                    }
                 }
                 filtered = filtered.sortedWith(Comparator<IndexedValue<ItemStack>> { a, b ->
                     val aType = a.value.itemType

--- a/shared-sources/src/main/java/org/anti_ad/mc/ipnext/event/AutoRefillHandler.kt
+++ b/shared-sources/src/main/java/org/anti_ad/mc/ipnext/event/AutoRefillHandler.kt
@@ -281,8 +281,6 @@ object AutoRefillHandler {
             if (storedItem.isEmpty()) return false // nothing become anything
             if (currentItem.isEmpty()) {
                 return !(AutoRefillSettings.DISABLE_FOR_LOYALTY_ITEMS.value && storedItem.itemType.enchantments[Enchantments.LOYALTY] != null)
-            } else if (currentItem.itemType.isStackable && currentItem.count <= AutoRefillSettings.STACKABLE_THRESHOLD.integerValue) {
-                return true
             }
             val itemType = currentItem.itemType
             if (itemType.isDamageable) {
@@ -310,7 +308,9 @@ object AutoRefillHandler {
                 true
             }  else if (storedItem.itemType.isHoneyBottle && currentItem.itemType.item == Items.GLASS_BOTTLE) {
                 true
-            } else storedItem.itemType.isStew && currentItem.itemType.item == Items.BOWL
+            } else if (storedItem.itemType.isStew && currentItem.itemType.item == Items.BOWL) {
+                true
+            } else currentItem.itemType.isStackable && currentItem.count <= AutoRefillSettings.STACKABLE_THRESHOLD.integerValue
 
         }
         private fun notifySuccessfulChange(itemType: ItemType,

--- a/shared-sources/src/main/java/org/anti_ad/mc/ipnext/event/AutoRefillHandler.kt
+++ b/shared-sources/src/main/java/org/anti_ad/mc/ipnext/event/AutoRefillHandler.kt
@@ -247,6 +247,10 @@ object AutoRefillHandler {
 
                 if (currentItem.itemType.isEmptyBucket || currentItem.itemType.item == Items.GLASS_BOTTLE) {
                     ContainerClicker.shiftClick(storedSlotId)
+                } else if (checkingItem.itemType.isStackable
+                    && checkingItem.itemType.item == currentItem.itemType.item
+                    && Vanilla.playerContainer().`(slots)`[foundSlotId].`(itemStack)`.count <= currentItem.count) {
+                    return
                 }
 
                 if ((storedSlotId - watchIds.mainHandOffset) in  0..8) { // use swap
@@ -515,11 +519,6 @@ object AutoRefillHandler {
                 } else {
                     // find item
                     filtered = defaultItemMatch(filtered, itemType)
-                    if (checkingItem.count > 1) {
-                        filtered = filtered.filter {
-                            it.value.count > checkingItem.count
-                        }
-                    }
                 }
                 filtered = filtered.sortedWith(Comparator<IndexedValue<ItemStack>> { a, b ->
                     val aType = a.value.itemType

--- a/shared-sources/src/main/resources/assets/inventoryprofilesnext/lang/en_us.json
+++ b/shared-sources/src/main/resources/assets/inventoryprofilesnext/lang/en_us.json
@@ -207,6 +207,7 @@
     "inventoryprofiles.config.name.auto_refill_match_any_food":                          "Refill With Any Food",
     "inventoryprofiles.config.name.auto_refill_match_harmful_food":                      "Allow refill with harmful foods.",
     "inventoryprofiles.config.name.autorefill_blacklist":                                "Blacklisted item types",
+    "inventoryprofiles.config.name.stackable_threshold":                                 "Stackable Threshold",
     "inventoryprofiles.config.name.tool_damage_threshold":                               "Damage Threshold",
     "inventoryprofiles.config.name.threshold_unit":                                      "Threshold Units",
     "inventoryprofiles.config.name.auto_refill_wait_tick":                               "Number of Ticks to Wait Before Auto Refill",
@@ -252,6 +253,7 @@
     "inventoryprofiles.config.description.auto_refill_match_harmful_food":               "When this and the above are set to true, harmful foods, like 'puffer fish', will also be uset to refill depleted food stacks.",
 
     "inventoryprofiles.config.description.autorefill_blacklist":                         "Comma separated list of item types to that will be ignored by Auto refill\nFor example 'minecraft:golden_axe,minecraft:stone'\nWARNING:\nTo avoid performance degradation DO NOT put too many item types in the list!",
+    "inventoryprofiles.config.description.stackable_threshold":                          "Controls the quantity in a stackable item that will trigger auto refill.",
     "inventoryprofiles.config.description.tool_damage_threshold":                        "Controls the durability level that will trigger auto refill.",
     "inventoryprofiles.config.description.threshold_unit":                               "Set the unit for \"Damage Threshold\".\nAbsolute value and percentage (%%) are supported.",
     "inventoryprofiles.config.description.auto_refill_wait_tick":                        "Auto refill will wait this many ticks before doing the swap. \nThis might be useful on some during high server lag. \nHowever, depending on the \"Damage Threshold\" value, the tool might break before a swap is initiated.",


### PR DESCRIPTION
This enables a refill to happen when an item stack's count falls within a certain threshold. It's similar to Tweakeroo's `handRestockPre` but utilizes IPN's more latency-immune refill. Fixes desyncs with Litematica's easy place mode on high-latency connections.