### PR TITLE
fix #260, and improve some ae2 and ae2wtlib screens

### DIFF
--- a/shared-sources/src/main/resources/assets/inventoryprofilesnext/config/ModIntegrationExport.json
+++ b/shared-sources/src/main/resources/assets/inventoryprofilesnext/config/ModIntegrationExport.json
@@ -44,16 +44,31 @@
         "appeng.client.gui.implementations.PatternProviderScreen": {
             "playerSideOnly": true
         },
+        "appeng.client.gui.implementations.SpatialIOPortScreen": {
+            "playerSideOnly": true
+        },
         "appeng.client.gui.implementations.SpatialAnchorScreen": {
             "ignore": true
         },
         "appeng.menu.implementations.SpatialAnchorMenu": {
             "ignore": true
         },
+        "appeng.client.gui.me.crafting.CraftAmountScreen": {
+            "ignore": true
+        },
+        "appeng.client.gui.me.items.SetProcessingPatternAmountScreen": {
+            "ignore": true
+        },
+        "appeng.client.gui.me.crafting.SetStockAmountScreen": {
+            "ignore": true
+        },
         "appeng.client.gui.implementations.VibrationChamberScreen": {
             "playerSideOnly": true
         },
         "appeng.client.gui.implementations.QNBScreen": {
+            "playerSideOnly": true
+        },
+        "appeng.client.gui.implementations.FormationPlaneScreen": {
             "playerSideOnly": true
         },
         "appeng.client.gui.me.common.MEStorageScreen": {
@@ -69,6 +84,51 @@
                     "horizontalOffset": 20
                 }
             }
+        },
+        "appeng.client.gui.me.items.CraftingTermScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                }
+            }
+        },
+        "appeng.client.gui.me.items.PatternEncodingTermScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                }
+            }
+        },
+        "appeng.client.gui.me.patternaccess.PatternAccessTermScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                }
+            }
+        },
+        "appeng.client.gui.implementations.StorageBusScreen": {
+            "playerSideOnly": true
         },
         "appeng.client.gui.implementations.IOBusScreen": {
             "playerSideOnly": true
@@ -122,6 +182,84 @@
         },
         "io.github.projectet.ae2things.gui.crystalGrowth.CrystalGrowthRootPanel": {
             "playerSideOnly": true
+        }
+    },
+    "ae2wtlib": {
+        "de.mari_023.ae2wtlib.wct.WCTScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                }
+            }
+        },
+        "de.mari_023.ae2wtlib.wet.WETScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                }
+            }
+        },
+        "de.mari_023.ae2wtlib.wat.WATScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                }
+            }
+        },
+        "de.mari_023.ae2wtlib.wct.magnet_card.config.MagnetScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "bottom": -1
+                },
+                "SORT_COLUMNS": {
+                    "bottom": -1
+                },
+                "SORT_ROWS": {
+                    "bottom": -1
+                }
+            }
+        },
+        "de.mari_023.ae2wtlib.wct.TrashScreen": {
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                },
+                "MOVE_TO_CONTAINER":   {
+                    "horizontalOffset": 20,
+                    "bottom": 29
+                },
+                "MOVE_TO_PLAYER":      {
+                    "horizontalOffset": 20
+                }
+            }
         }
     },
     "agap": {

--- a/shared-sources/src/main/resources/assets/inventoryprofilesnext/config/ModIntegrationHintsNG.json
+++ b/shared-sources/src/main/resources/assets/inventoryprofilesnext/config/ModIntegrationHintsNG.json
@@ -44,16 +44,31 @@
         "appeng.client.gui.implementations.PatternProviderScreen": {
             "playerSideOnly": true
         },
+        "appeng.client.gui.implementations.SpatialIOPortScreen": {
+            "playerSideOnly": true
+        },
         "appeng.client.gui.implementations.SpatialAnchorScreen": {
             "ignore": true
         },
         "appeng.menu.implementations.SpatialAnchorMenu": {
             "ignore": true
         },
+        "appeng.client.gui.me.crafting.CraftAmountScreen": {
+            "ignore": true
+        },
+        "appeng.client.gui.me.items.SetProcessingPatternAmountScreen": {
+            "ignore": true
+        },
+        "appeng.client.gui.me.crafting.SetStockAmountScreen": {
+            "ignore": true
+        },
         "appeng.client.gui.implementations.VibrationChamberScreen": {
             "playerSideOnly": true
         },
         "appeng.client.gui.implementations.QNBScreen": {
+            "playerSideOnly": true
+        },
+        "appeng.client.gui.implementations.FormationPlaneScreen": {
             "playerSideOnly": true
         },
         "appeng.client.gui.me.common.MEStorageScreen": {
@@ -69,6 +84,51 @@
                     "horizontalOffset": 20
                 }
             }
+        },
+        "appeng.client.gui.me.items.CraftingTermScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                }
+            }
+        },
+        "appeng.client.gui.me.items.PatternEncodingTermScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                }
+            }
+        },
+        "appeng.client.gui.me.patternaccess.PatternAccessTermScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                }
+            }
+        },
+        "appeng.client.gui.implementations.StorageBusScreen": {
+            "playerSideOnly": true
         },
         "appeng.client.gui.implementations.IOBusScreen": {
             "playerSideOnly": true
@@ -122,6 +182,84 @@
         },
         "io.github.projectet.ae2things.gui.crystalGrowth.CrystalGrowthRootPanel": {
             "playerSideOnly": true
+        }
+    },
+    "ae2wtlib": {
+        "de.mari_023.ae2wtlib.wct.WCTScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                }
+            }
+        },
+        "de.mari_023.ae2wtlib.wet.WETScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                }
+            }
+        },
+        "de.mari_023.ae2wtlib.wat.WATScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                }
+            }
+        },
+        "de.mari_023.ae2wtlib.wct.magnet_card.config.MagnetScreen": {
+            "playerSideOnly": true,
+            "buttonHints": {
+                "SORT": {
+                    "bottom": -1
+                },
+                "SORT_COLUMNS": {
+                    "bottom": -1
+                },
+                "SORT_ROWS": {
+                    "bottom": -1
+                }
+            }
+        },
+        "de.mari_023.ae2wtlib.wct.TrashScreen": {
+            "buttonHints": {
+                "SORT": {
+                    "horizontalOffset": 20
+                },
+                "SORT_COLUMNS": {
+                    "horizontalOffset": 20
+                },
+                "SORT_ROWS": {
+                    "horizontalOffset": 20
+                },
+                "MOVE_TO_CONTAINER":   {
+                    "horizontalOffset": 20,
+                    "bottom": 29
+                },
+                "MOVE_TO_PLAYER":      {
+                    "horizontalOffset": 20
+                }
+            }
         }
     },
     "agap": {


### PR DESCRIPTION
All ae2wtlib terminal screens are now set to `playerSideOnly`, so it doesn't sort the armour, upgrades and crafting inventory. This fixes #260.

all ae2 config screens that don't have any player inventory are now set to `ignore`, the config screens that have an inventory are set to `playerSideOnly`
sort buttons have been moved slightly on some screens to not overlap with other elements of the GUI.

there is however the remaining issue that pressing the sort button sorts the inventory, even tho the search bar is focused, but at least it only sorts the actual player inventory now.



#384 seems to suggest that one has to change `ModIntegrationExport.json`, but that doesn't seem to have any effect. changing `ModIntegrationHintsNG.json` however works

I changed both, since they seem to be nearly identical, apart from a few lines which are only present in `ModIntegrationHintsNG.json` 