### PR TITLE
Disable focused item highlighting by default

### DIFF
--- a/platforms/shared-1.20.5+/src/main/java/org/anti_ad/mc/ipnext/config/Configs.kt
+++ b/platforms/shared-1.20.5+/src/main/java/org/anti_ad/mc/ipnext/config/Configs.kt
@@ -99,7 +99,7 @@ object ModSettings : ConfigDeclaration {
     val ALWAYS_THROW_ALL                          /**/ by bool(false)
 
         .CATEGORY("$category.highlight_focused_items")
-    val HIGHLIGHT_FOUSED_ITEMS                    /**/ by keyToggleBool(true, KeybindSettings.GUI_DEFAULT)
+    val HIGHLIGHT_FOUSED_ITEMS                    /**/ by keyToggleBool(false, KeybindSettings.GUI_DEFAULT)
     val HIGHLIGHT_FOUSED_ITEMS_ANIMATED           /**/ by keyToggleBool(false, KeybindSettings.GUI_DEFAULT)
     val HIGHLIGHT_FOUSED_ITEMS_FOREGROUND         /**/ by bool(true)
     val HIGHLIGHT_FOUSED_ITEMS_COLOR              /**/ by color(0x70.asAlpha().red(1).green(0xB6).blue(0x0b))


### PR DESCRIPTION
This pull request sets the config option for focused item highlighting to be off by default. This feature is often unexpected to users, as it is not explicitly mentioned in the mod description, and it may cause confusion as to what mod causes it. This is often undesirable, and not expected to be caused by the mod.

By settings it to be off by default, it prevents confusion from the behavior being on, yet can still be used by players who wish to use the feature.